### PR TITLE
Ignore notifications without subjects

### DIFF
--- a/ghb/ls_notifications.py
+++ b/ghb/ls_notifications.py
@@ -18,6 +18,8 @@ def main(_):
     for blob in r.json():
         repo_name = blob["repository"]["full_name"]
         api_url = blob["subject"]["url"]
+        if not api_url:
+            continue
         html_url = (
             api_url.replace("api.", "", 1)
             .replace("/repos", "", 1)


### PR DESCRIPTION
This isn't ideal but I probably am not handling notifications like
github actions CI, releases, security notifs, that don't have this. So
at least with this it doesn't crash.